### PR TITLE
Sanitize flash messages

### DIFF
--- a/app/views/application/_flash_notices.html.slim
+++ b/app/views/application/_flash_notices.html.slim
@@ -2,12 +2,12 @@
   .container
     - if flash.notice
       .alert.alert-success.alert-dismissable.fade.show role="alert"
-        = flash.notice
+        = sanitize flash.notice
         button.close type="button" data-dismiss="alert" aria-label="Close"
           span aria-hidden="true" &times;
     - if flash.alert
       .alert.alert-warning.alert-dismissible.fade.show role="alert"
-        = flash.alert
+        = sanitize flash.alert
         button.close type="button" data-dismiss="alert" aria-label="Close"
           span aria-hidden="true" &times;
 


### PR DESCRIPTION
## Summary

While working on Identity's internal pages, we noticed some messages not being rendered properly.

Example:

<img width="1439" alt="Screen Shot 2020-05-07 at 4 13 17 PM" src="https://user-images.githubusercontent.com/38059761/81340484-ed041180-907d-11ea-90bf-732657efe024.png">

This PR sanitizes the flash notice and alert messages so that the error message is nicer. Now the same example looks like:

<img width="1435" alt="Screen Shot 2020-05-07 at 4 13 04 PM" src="https://user-images.githubusercontent.com/38059761/81340529-02793b80-907e-11ea-87fc-33969d1e17c4.png">
